### PR TITLE
Removed warnings to speed up the process doing https requests

### DIFF
--- a/pysibyl/askbot.py
+++ b/pysibyl/askbot.py
@@ -29,6 +29,8 @@ from BeautifulSoup import BeautifulSoup
 from pysibyl.db import People, Questions, Tags, QuestionsTags, Answers, Comments
 from pysibyl.utils import JSONParser
 
+from requests.packages import urllib3
+urllib3.disable_warnings()
 
 class QuestionsIter(object):
     """Iterator to go through the set of questions

--- a/pysibyl/discourse.py
+++ b/pysibyl/discourse.py
@@ -26,6 +26,8 @@ import requests
 from pysibyl.db import People, Questions, Tags, QuestionsTags, Answers, Comments
 from pysibyl.utils import JSONParser
 
+from requests.packages import urllib3
+urllib3.disable_warnings()
 
 class Discourse(object):
     """Discourse main class

--- a/pysibyl/stackoverflow.py
+++ b/pysibyl/stackoverflow.py
@@ -28,6 +28,9 @@ import time
 from pysibyl.db import People, Questions, Tags, QuestionsTags, Answers, Comments
 from pysibyl.utils import JSONParser
 
+from requests.packages import urllib3
+urllib3.disable_warnings()
+
 class StackSampleData(object):
     """Sample data from StackExchange API to debug without doing real queries"""
     @staticmethod


### PR DESCRIPTION
As we are not using any certificate for doing HTTPS requests (all of them are done with the field `Verify=False`) we can disable warnings to speed up the process as stands in the [urllib3 documentation](https://urllib3.readthedocs.org/en/latest/security.html#insecurerequestwarning)
